### PR TITLE
Add smooth scrolling and disable text size adjustment

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -54,11 +54,12 @@ body.dark {
 html {
   font-family: Poppins, serif;
   font-weight: 400;
+  -webkit-scroll-behavior: smooth;
   scroll-behavior: smooth;
   scroll-padding-top: calc(var(--padding-section) + 2rem);
   font-size: clamp(1rem, 3vmin, 1.5rem);
-  text-size-adjust: none;
   -webkit-text-size-adjust: none;
+  text-size-adjust: none;
 }
 
 *::selection {
@@ -99,6 +100,7 @@ body {
 
 img {
   user-select: none;
+  -webkit-user-select: none;
 }
 
 .Home {

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,7 @@ html {
   scroll-padding-top: calc(var(--padding-section) + 2rem);
   font-size: clamp(1rem, 3vmin, 1.5rem);
   text-size-adjust: none;
+  -webkit-text-size-adjust: none;
 }
 
 *::selection {


### PR DESCRIPTION
Not everythign can be fixed from the original site build. To many custom componants. FireFox and Safari support too few modern features of design. The supported featurs in question should not affect performance or rendering. The browser will default to its own way of handling the site. Mobile and desktop included. 